### PR TITLE
Fix region mismatch between deploy and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ gcloud run deploy badger \
   --image gcr.io/hightowerlabs/badger:0.0.1 \
   --memory '128Mi' \
   --platform managed \
-  --region us-west1
+  --region us-central1
 ```
 
 ### Test the Installation
@@ -91,7 +91,7 @@ Retrieve the badger Cloud Run service url:
 ```
 BADGER_ENDPOINT=$(gcloud run services describe badger \
   --platform managed \
-  --region us-east1 \
+  --region us-central1 \
   --format 'value(status.url)')
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Retrieve the service URL associated with your `badger` deployment:
 ```
 BADGER_ENDPOINT=$(gcloud run services describe badger \
   --platform managed \
-  --region us-east1 \
+  --region us-central1 \
   --format 'value(status.url)')
 ```
 


### PR DESCRIPTION
Also switch to us-central1 (as it is where Cloud Run has the most capacity today).